### PR TITLE
Add a configurable analytics reducer. Track GoogleAnalytics

### DIFF
--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -44,10 +44,12 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-63691338-6"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-63691338-6');
+      window.dataLayer = window.dataLayer || []
+      window.GA_TRACKING_ID = 'UA-63691338-6'
+
+      function gtag(){
+        window.dataLayer.push(arguments)
+      }
     </script>
 
   </body>

--- a/webapp/src/analyticsMiddleware.js
+++ b/webapp/src/analyticsMiddleware.js
@@ -1,0 +1,22 @@
+export default function createAnalyticsMiddleware(sendEvent, reducer) {
+  if (!reducer) reducer = action => action
+
+  return store => next => action => {
+    if (sendEvent) {
+      const event = reducer(store.getState(), action)
+
+      if (event != null) {
+        sendEvent(event)
+      }
+    }
+
+    return next(action)
+  }
+}
+
+export function createGoogleAnalyticsMiddleware(reducer) {
+  return createAnalyticsMiddleware(action => {
+    const { type, ...data } = action
+    window.gtag('event', type, data)
+  }, reducer)
+}

--- a/webapp/src/components/HomePage.js
+++ b/webapp/src/components/HomePage.js
@@ -8,6 +8,7 @@ import ParcelsMapContainer from '../containers/ParcelsMapContainer'
 import ModalContainer from '../containers/modals/ModalContainer'
 import ShiftNotificationContainer from '../containers/ShiftNotificationContainer'
 import MinimapContainer from '../containers/MinimapContainer'
+import GoogleAnalyticsContainer from '../containers/GoogleAnalyticsContainer'
 
 import './HomePage.css'
 
@@ -25,6 +26,7 @@ export default function HomePage({ requiredDataReady }) {
       {requiredDataReady && <MinimapContainer />}
       <ParcelsMapContainer requiredDataReady={requiredDataReady} />
       <ModalContainer />
+      <GoogleAnalyticsContainer />
     </div>
   )
 }

--- a/webapp/src/containers/GoogleAnalyticsContainer.js
+++ b/webapp/src/containers/GoogleAnalyticsContainer.js
@@ -39,6 +39,7 @@ class GoogleAnalyticsContainer extends React.Component {
     window.gtag('config', window.GA_TRACKING_ID, {
       user_id: address
     })
+    this.configurated = true
   }
 
   render() {

--- a/webapp/src/containers/GoogleAnalyticsContainer.js
+++ b/webapp/src/containers/GoogleAnalyticsContainer.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+
+import { selectors } from '../reducers'
+import { stateData } from '../lib/propTypes'
+
+class GoogleAnalyticsContainer extends React.Component {
+  static propTypes = {
+    addressState: stateData(PropTypes.object).isRequired
+  }
+
+  constructor(props) {
+    super(props)
+    this.configurated = false
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.shouldConfig()) {
+      this.config()
+    }
+  }
+
+  shouldConfig() {
+    const { addressState } = this.props
+    return !this.configurated && !addressState.loading && !addressState.error
+  }
+
+  config() {
+    if (!window.gtag) {
+      throw new Error(
+        'Tried to config google analytics tracking code without injecting the script on the HTML first'
+      )
+    }
+
+    const { address } = this.props.addressState.data
+
+    window.gtag('js', new Date())
+    window.gtag('config', window.GA_TRACKING_ID, {
+      user_id: address
+    })
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default connect(
+  state => ({
+    addressState: selectors.getAddressState(state)
+  }),
+  {}
+)(GoogleAnalyticsContainer)

--- a/webapp/src/reducers.js
+++ b/webapp/src/reducers.js
@@ -280,3 +280,18 @@ export default {
   shift,
   range
 }
+
+export function analytics(state, action) {
+  switch (action.type) {
+    case '@@router/LOCATION_CHANGE':
+      return null
+    case types.fetchParcels.success:
+      return Object.assign({}, action, {
+        parcelStates: action.parcelStates.length
+      })
+    case types.fetchProjects.success:
+      return Object.assign({}, action, { projects: action.projects.length })
+    default:
+      return action
+  }
+}

--- a/webapp/src/store.js
+++ b/webapp/src/store.js
@@ -6,7 +6,9 @@ import createSagasMiddleware from 'redux-saga'
 import reduxThunk from 'redux-thunk'
 import { createLogger } from 'redux-logger'
 
-import reducers from './reducers'
+import { createGoogleAnalyticsMiddleware } from './analyticsMiddleware'
+
+import reducers, { analytics } from './reducers'
 import rootSaga from './sagas'
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
@@ -18,13 +20,23 @@ const history = createHistory()
 const historyMiddleware = routerMiddleware(history)
 
 const sagasMiddleware = createSagasMiddleware()
+
+const analyticsMiddleware = createGoogleAnalyticsMiddleware(analytics)
+
 const store = createStore(
   combineReducers({
     ...reducers,
     router: routerReducer
   }),
+
   composeEnhancers(
-    applyMiddleware(reduxThunk, logger, sagasMiddleware, historyMiddleware)
+    applyMiddleware(
+      reduxThunk,
+      logger,
+      sagasMiddleware,
+      historyMiddleware,
+      analyticsMiddleware
+    )
   )
 )
 


### PR DESCRIPTION
# README

1. I tried to keep the code generic and extractable so we can reuse it later (and move it into `commons` !). I didn't yet abstract it away into a library to battle test it first
2. This is reporting `dev events` without any kind of check (https://github.com/decentraland/auction/compare/analytics?expand=1#diff-988ccd9de4f73ecd0f56726a68e08a2eR36). We could add something like `if (env.isProduction()) configure()`, but as I said [here](https://github.com/decentraland/auction/pull/30), I'm afraid this could lead to problems with `test/beta` deployments. SO I advice we filter `localhost` events **from the analytics platform itself**
3. The code on `index.html` can easily be extracted into `<GoogleAnalytics />` and injected dynamically but I'm not sure if it's worthwhile. On one hand we stop having to add extra code outside `React`, on the other, we **have** to make sure the component is always mounted which right now amounts to adding a new `<Page>` component to wrap every route. What do you think? (dear reviewer)

That's it!