### PR TITLE
Blacklist properties when returning parcel states

### DIFF
--- a/src/lib/omitInArray.js
+++ b/src/lib/omitInArray.js
@@ -1,0 +1,5 @@
+import { utils } from 'decentraland-commons'
+
+export default function omitInArray(array, props = []) {
+  return array.map(obj => utils.omit(obj, props))
+}


### PR DESCRIPTION
There's a lot of room for improvement here, but I settled for a basic extensible implementation.

If we measure and realize that we're spending more time over the wire that on computing, we can take this one step further and try removing unnecessary `nulls`

![image](https://user-images.githubusercontent.com/692077/33900646-7ea5fbb6-df6f-11e7-8303-c30e84b6bfbe.png)
