### PR TITLE
Use big number to avoid rounding errors

### DIFF
--- a/webapp/src/lib/LeafletMapCoordinates.js
+++ b/webapp/src/lib/LeafletMapCoordinates.js
@@ -1,4 +1,5 @@
 import L from 'leaflet'
+import { eth } from 'decentraland-commons'
 
 export default class LeafletMapCoordinates {
   constructor(baseZoom) {
@@ -26,11 +27,20 @@ export default class LeafletMapCoordinates {
   }
 
   latLngToCartesian({ lng, lat }) {
-    const mapSize = this.getMapSize()
-    const offset = this.getOffset()
+    const mapSize = getBn(this.getMapSize())
+    const offset = getBn(this.getOffset())
 
-    const x = Math.round(lng * offset / mapSize)
-    const y = Math.round(lat * offset / mapSize)
+    const x = getBn(lng)
+      .mul(offset)
+      .dividedBy(mapSize)
+      .round()
+      .toNumber()
+
+    const y = getBn(lat)
+      .mul(offset)
+      .dividedBy(mapSize)
+      .round()
+      .toNumber()
 
     return { x, y }
   }
@@ -52,4 +62,12 @@ export default class LeafletMapCoordinates {
     // leaflet considers the map as going from `-180` to `180
     return 180
   }
+}
+
+const bnCache = {}
+function getBn(number) {
+  if (!bnCache[number]) {
+    bnCache[number] = new eth.utils.toBigNumber(number)
+  }
+  return bnCache[number]
 }

--- a/webapp/src/lib/LeafletParcelGrid.js
+++ b/webapp/src/lib/LeafletParcelGrid.js
@@ -215,8 +215,7 @@ const LeafletParcelGrid = L.FeatureGroup.extend({
         tiles.push({
           id: row + ':' + col,
           bounds: tileBounds,
-          center: tileCenter,
-          distance: tileCenter.distanceTo(mainCenter)
+          center: tileCenter
         })
       }
     }

--- a/webapp/src/lib/LeafletParcelGrid.js
+++ b/webapp/src/lib/LeafletParcelGrid.js
@@ -201,8 +201,6 @@ const LeafletParcelGrid = L.FeatureGroup.extend({
 
   getCellsInBounds(bounds) {
     const offset = this.getBoundsOffset(bounds)
-    const mainCenter = bounds.getCenter()
-
     const tiles = []
 
     for (let i = 0; i <= this.rows; i++) {


### PR DESCRIPTION
Tries to fix this:

![image](https://user-images.githubusercontent.com/692077/33906434-354d1784-df82-11e7-9649-b219167e932d.png)

I was able to reproduce the bug (on `master`) by using the responsive version of devtools with this settings:

![image](https://user-images.githubusercontent.com/692077/33906461-5c4f3286-df82-11e7-8571-8e287056a084.png)

And looking at `-60, -40` with and without that setting turned on