### PR TITLE
Hardcode the max-amount and use the parcel amount if it's surpassed

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,7 +32,6 @@
     "redux-logger": "^3.0.6",
     "redux-saga": "^0.16.0",
     "redux-thunk": "^2.2.0",
-    "reselect": "^3.0.1",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {

--- a/webapp/src/lib/parcelUtils.js
+++ b/webapp/src/lib/parcelUtils.js
@@ -83,6 +83,8 @@ export function getBidStatus(parcel, addressState) {
 }
 
 export function getColorByAmount(amount, maxAmount) {
+  maxAmount = amount > maxAmount ? amount : maxAmount
+
   // toHsv() => { h: 0, s: 1, v: 1, a: 1 }
   const h = memorizedHue(amount, maxAmount)
   const s = memorizedSat(amount, maxAmount)

--- a/webapp/src/reducers.js
+++ b/webapp/src/reducers.js
@@ -1,5 +1,3 @@
-import { createSelector } from 'reselect'
-
 import types from './types'
 import localStorage from './lib/localStorage'
 
@@ -60,17 +58,7 @@ function getParcelStates(state) {
   return state.parcelStates
 }
 
-const getMaxAmount = createSelector(
-  [getParcelStates],
-  parcelStates =>
-    parcelStates && !parcelStates.loading
-      ? Object.values(parcelStates).reduce(
-          (prev, next) =>
-            next && next.amount ? Math.max(prev, next.amount) : prev,
-          0
-        )
-      : 50000
-)
+const getMaxAmount = () => 50000
 
 function getPendingConfirmationBids(state) {
   return state.pendingConfirmationBids


### PR DESCRIPTION
@eordano What do you think of this implementation?

Another way to accomplish the same thing is to keep the current `createSelector` and always return `50000` except when there's a bigger amount. In contrast, right now we're always returning the max amount, which widely varies.

It'll look something like this:

```javascript
const getMaxAmount = createSelector([getParcelStates], parcelStates => {
  const minAmount = 50000

  const amount =
    parcelStates && !parcelStates.loading
      ? Object.values(parcelStates).reduce(
          (prev, next) =>
            next && next.amount ? Math.max(prev, next.amount) : prev,
          0
        )
      : minAmount

  return Math.max(minAmount, amount)
})
```

What I don't like about this last one it's that there's still a high chance for blinking colors if there are too many parcels with an amount bigger than `50000`