### PR TITLE
Don't break on frantic movement

### DIFF
--- a/webapp/src/lib/LeafletParcelGrid.js
+++ b/webapp/src/lib/LeafletParcelGrid.js
@@ -116,6 +116,7 @@ const LeafletParcelGrid = L.FeatureGroup.extend({
       this.loadedTiles[tile.id] = rect
     } else if (this.tileChanged(loadedTile, className, fillColor)) {
       const element = loadedTile.getElement()
+      if (!element) return
 
       element.removeAttribute('style')
 


### PR DESCRIPTION
If you move around the map too quickly, there's a chance leaflet didn't load the element (yet). Don't blow up on those cases