### PR TITLE
Avoid firing onMoveEnd on URL navigation if the map is not defined

### DIFF
--- a/webapp/src/components/ParcelsMap.js
+++ b/webapp/src/components/ParcelsMap.js
@@ -167,7 +167,9 @@ export default class ParcelsMap extends React.Component {
   }
 
   onMoveEnd = () => {
-    this.props.onMoveEnd(this.getCurrentPositionAndBounds())
+    if (this.map) {
+      this.props.onMoveEnd(this.getCurrentPositionAndBounds())
+    }
   }
 
   getCurrentPositionAndBounds() {


### PR DESCRIPTION
It's not a consistent bug, but it happened a few times navigating back and forth from stats